### PR TITLE
docs: add Linux setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,15 @@ bun install
 bun link
 ```
 
-**Requirements:** [Bun](https://bun.sh) v1.0+, [Homebrew SQLite](https://formulae.brew.sh/formula/sqlite) (macOS), optionally [Ollama](https://ollama.com) for vector search.
+**Requirements:** [Bun](https://bun.sh) v1.0+, SQLite with development headers, optionally [Ollama](https://ollama.com) for vector search.
+
+**SQLite setup by platform:**
+
+- **macOS:** `brew install sqlite`
+- **Ubuntu/Debian:** `sudo apt-get install libsqlite3-dev`
+- **Fedora/RHEL:** `sudo dnf install sqlite-devel`
+
+The `sqlite-vec` extension is bundled and works on macOS (x64/arm64) and Linux (x64/arm64). No extra steps needed.
 
 Full walkthrough → **[Getting Started](docs/getting-started.md)**
 


### PR DESCRIPTION
## Summary

- Added SQLite installation instructions for Linux (Ubuntu/Debian via apt-get, Fedora/RHEL via dnf) alongside the existing macOS Homebrew command
- Noted that the bundled `sqlite-vec` extension works cross-platform on macOS and Linux (x64/arm64)
- Kept changes minimal — only the Requirements section was updated

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm `apt-get install libsqlite3-dev` works on Ubuntu/Debian
- [ ] Confirm `dnf install sqlite-devel` works on Fedora/RHEL

🤖 Generated with [Claude Code](https://claude.com/claude-code)