### PR TITLE
chore: add .claude/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 *.pem
 *.key
 credentials.json
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Add `.claude/worktrees/` to `.gitignore` — agent worktrees are temporary and should not be tracked

## Test plan
- [x] Verify worktree directories no longer show in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)